### PR TITLE
qTox shouldn't depend on GCC

### DIFF
--- a/Formula/qtox.rb
+++ b/Formula/qtox.rb
@@ -6,7 +6,7 @@ class Qtox < Formula
   
   depends_on "Tox/tox/libtoxcore"
   depends_on "qt5"
-  depends_on "homebrew/science/opencv"
+  depends_on "homebrew/science/opencv" => "without-brewed-numpy"
   depends_on "ReDetection/qtox/libfilteraudio"
   depends_on "qrencode"
 


### PR DESCRIPTION
By default, OpenCV builds with Numpy, which requires GCC for some reason. Since we don't need Numpy, it would be a good idea to disable OpenCV building with it, as compiling GCC is very unnecessary.
